### PR TITLE
I2 fav indicator link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+coverage

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,7 +15,7 @@
       <nav class="menu">
         <%= link_to 'Pets', '/pets' %>
         <%= link_to 'Shelters', '/shelters' %>
-        <p>Favorite Pet Count: <%= favorites.total_count %></p>
+        <%= link_to "Favorite Pet Count: #{favorites.total_count}", '/favorites' %>
       </nav>
     </header>
 

--- a/spec/features/layout/application_spec.rb
+++ b/spec/features/layout/application_spec.rb
@@ -7,5 +7,13 @@ RSpec.describe "As a visitor" do
 
       expect(page).to have_content('Favorite Pet Count: 0')
     end
+
+    it "when I click on the favorite indicator in the nav bar" do
+      visit '/shelters'
+
+      click_link 'Favorite Pet Count: 0'
+
+      expect(current_path).to eq('/favorites')
+    end
   end
 end


### PR DESCRIPTION
This PR turns the nav bar favorites indicator into a link to the favorites index page.

Also added coverage to gitignore.