### PR TITLE
I2 delete route refactor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,7 @@ group :development, :test do
   gem 'simplecov'
   gem 'pry'
   gem 'shoulda-matchers', '~> 3.1'
+  gem "nyan-cat-formatter"
 end
 
 group :development do

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -16,12 +16,11 @@ class FavoritesController < ApplicationController
     end
   end
 
-
   def delete
     session[:favorites].delete(params[:pet_id])
     redirect_to '/favorites'
   end
-  
+
   def destroy
     if params[:pet_id]
       pet = Pet.find(params[:pet_id])

--- a/app/views/favorites/index.html.erb
+++ b/app/views/favorites/index.html.erb
@@ -9,7 +9,7 @@
       <article id="pet-<%= pet.id %>" class='pet card'>
         <p><%= link_to "#{pet.name}", "/pets/#{pet.id}" %></p>
         <img src=<%= pet.image %> />
-        <p><%= button_to "Remove from favorites", "/favorites/#{pet.id}", method: :delete %>
+        <p><%= button_to "Remove from favorites", "/favorites/index/#{pet.id}", method: :delete %>
       </article>
     <% end %>
     <%= button_to "Remove All Favorited Pets", "/favorites", method: :delete %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,7 +28,7 @@ Rails.application.routes.draw do
   patch '/favorites/:pet_id', to: 'favorites#update'
   delete '/favorites', to: 'favorites#destroy'
   delete '/favorites/:pet_id', to: 'favorites#destroy'
+  delete '/favorites/index/:pet_id', to: 'favorites#delete'
   get '/favorites', to: 'favorites#index'
-  delete '/favorites/:pet_id', to: 'favorites#delete'
 
 end

--- a/spec/features/favorites/index_spec.rb
+++ b/spec/features/favorites/index_spec.rb
@@ -89,46 +89,62 @@ RSpec.describe 'As a visitor' do
     end
 
     it "I can see a button to remove favorite next to each pet name" do
-          visit "/pets/#{@pet_1.id}"
+      visit "/pets/#{@pet_1.id}"
 
-          click_button 'Add to favorites'
+      click_button 'Add to favorites'
 
-          visit "/pets/#{@pet_2.id}"
+      visit "/pets/#{@pet_2.id}"
 
-          click_button 'Add to favorites'
+      click_button 'Add to favorites'
 
-          visit "/favorites"
+      visit "/favorites"
 
-          within "#pet-#{@pet_1.id}" do
-            expect(page).to have_button("Remove from favorites")
-          end
+      within "#pet-#{@pet_1.id}" do
+        expect(page).to have_button("Remove from favorites")
+      end
 
-          within "#pet-#{@pet_2.id}" do
-            expect(page).to have_button("Remove from favorites")
-          end
+      within "#pet-#{@pet_2.id}" do
+        expect(page).to have_button("Remove from favorites")
+      end
     end
 
-    describe "when I click a remove favorite button" do
-      it "I no longer sees that favorite on the page" do
+    describe 'when I click a remove favorite button' do
+      it 'I no longer sees that favorite on the page' do
         visit "/pets/#{@pet_1.id}"
 
+        click_button 'Add to favorites'
+
+        visit '/favorites'
+        
+        click_button('Remove from favorites')
+
+        expect(page).to_not have_content("#{@pet_1.name}")
+      end
+
+      it 'the favorite pet indicator is decremented by 1' do
+        visit "/pets/#{@pet_1.id}"
 
         click_button 'Add to favorites'
 
-        visit "/pets/#{@pet_2.id}"
+        expect(page).to have_content('Favorite Pet Count: 1')
+
+        visit '/favorites'
+
+        click_button('Remove from favorites')
+
+        expect(page).to have_content('Favorite Pet Count: 0')
+      end
+
+      it 'I should see you have not favorited any pets yet if there are no more favorites' do
+        visit "/pets/#{@pet_1.id}"
 
         click_button 'Add to favorites'
 
-        visit "/favorites"
+        visit '/favorites'
 
-        all(:button, 'Remove from favorites')[0].click
+        click_button('Remove from favorites')
 
-        expect(page).to_not have_content("#{@pet_1.image}")
-        expect(page).to have_content("Favorite Pet Count: 1")
-
-        click_button 'Remove from favorites'
         expect(page).to have_content("You haven't favorited any pets yet.")
-        expect(page).to have_content("Favorite Pet Count: 0")
       end
     end
   end

--- a/spec/features/pets/show_spec.rb
+++ b/spec/features/pets/show_spec.rb
@@ -181,7 +181,6 @@ RSpec.describe 'As a visitor' do
           click_button 'Remove from favorites'
 
           within('.menu') do
-            save_and_open_page
             expect(page).to have_content('Favorite Pet Count: 0')
           end
         end


### PR DESCRIPTION
This PR is a duct tape solution for our delete pet fav routes and makes it so all our tests are passing again.

The main thing I did was change the index delete route to be different from the show page delete route.

Other things I did in this PR:

I also broke up a test in fav index spec into smaller tests
Add nyan cat formatter to gemfile
