### PR TITLE
I4 only one app approval

### DIFF
--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -33,7 +33,6 @@ class ApplicationsController < ApplicationController
       redirect_to "/pets/#{pet.id}"
     else
       pet.update(status: 'adoptable')
-      # flash[:notice] = 'No more applications can be approved for this pet at this time'
       redirect_to "/applications/#{params[:application_id]}"
     end
   end

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -1,6 +1,6 @@
 <article class='pet-application-details'>
   <h2>Pet Application Number <%= @application.id %></h2>
-  <p>Name: <%= @application.name %></p>
+  <p>Name: <%= link_to "#{@application.name}", "/applications/#{@application.id}"%></p>
   <p>Address: <%= @application.address %></p>
   <p>City: <%= @application.city %></p>
   <p>State: <%= @application.state %></p>

--- a/spec/features/applications/show_spec.rb
+++ b/spec/features/applications/show_spec.rb
@@ -189,6 +189,16 @@ RSpec.describe 'As a visitor' do
             expect(page).to have_content("Adoptable Status: adoptable")
           end
         end
+
+        describe "I see the applicant's name as a link" do
+          it "When I click the link it takes me to the application show page" do
+            visit "/applications/#{@application.id}"
+
+            expect(page).to have_link('Phil')
+            click_link 'Phil'
+            expect(current_path).to eq("/applications/#{@application.id}")
+          end
+        end
       end
     end
   end

--- a/spec/features/applications/show_spec.rb
+++ b/spec/features/applications/show_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'As a visitor' do
         phone_number: '3434343434',
         description: 'some text'
       )
-      application_2 = Application.create!(
+      @application_2 = Application.create!(
         name: 'Ryan',
         address: '33 different st',
         city: 'Denver',
@@ -36,7 +36,7 @@ RSpec.describe 'As a visitor' do
         description: 'some text'
       )
       @pet_application = PetApplication.create!(application: @application, pet: @pet_1)
-      @pet_application_2 = PetApplication.create!(application: application_2, pet: @pet_1)
+      @pet_application_2 = PetApplication.create!(application: @application_2, pet: @pet_1)
     end
 
     it 'I can see the application name, address, city, state, zip, phone number, and description' do
@@ -88,15 +88,12 @@ RSpec.describe 'As a visitor' do
         describe "When the pet already has an approved application" do
           describe "And I try to approve another application" do
             it "I see a flash message that no more applications can be approved" do
-              skip
               visit "/applications/#{@application.id}"
               click_link 'Approve Application'
 
               visit "/applications/#{@application_2.id}"
 
-              click_link 'Approve Application'
-
-              expect(page).to have_content('No more applications can be approved for this pet at this time')
+              expect(page).to_not have_link('Approve Application')
             end
           end
         end


### PR DESCRIPTION
I just changed the test to verify an 'Approve application' button is not present for a pet with an already approved application. I'm not entirely satisfied with this, I think a session that holds the ids of apps that have been approved could be used to differentiate the applications on their show pages, or a column for pets that would hold the id of its approved application (this second option actually sounds much less complicated).